### PR TITLE
Allow hyphens in masked link domain names

### DIFF
--- a/message_helper/message_regex.py
+++ b/message_helper/message_regex.py
@@ -6,7 +6,7 @@ colon_regex = re.compile(
     r"(?P<unrendered_emote>:(?:[a-zA-Z0-9_]+-)?[a-zA-Z0-9_]+:(?!\d+>))|"
     r"(?P<message_link>\b(?:https?://(?:[a-z]+\.)?)?discord(?:app)?\.com/channels/\d+/\d+/\d+\b(?!>))|"
     r"(?P<sticker>:[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+:)|"
-    r"(?P<masked_url>\[.*\]\(<?https?://[a-zA-Z0-9:.-_]{1,256}\.[a-zA-Z0-9]{1,6}\b[-a-zA-Z0-9@:%_+.~#?&/=]*>?\))"
+    r"(?P<masked_url>\[.*\]\(<?https?://[-a-zA-Z0-9:._]{1,256}\.[a-zA-Z0-9]{1,6}\b[-a-zA-Z0-9@:%_+.~#?&/=]*>?\))"
 )
 
 


### PR DESCRIPTION
The current regex doesn't match masked links when the domain name contains a hyphen. The way the regex is written (`[.-_]`), it will match any character between `.` (56) and `_` (95) instead of matching a hyphen, period and underscore. This should fix that.

![image](https://user-images.githubusercontent.com/36977340/100820948-59c96980-341d-11eb-896d-0cab29deb9a5.png)
![image](https://user-images.githubusercontent.com/36977340/100820689-c001bc80-341c-11eb-89dd-396ba9f5e27b.png)
